### PR TITLE
Fix evergreen_23.lts.1+ workflow.

### DIFF
--- a/.github/workflows/evergreen_23.lts.1+.yaml
+++ b/.github/workflows/evergreen_23.lts.1+.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
     branches:
-
+      - '23.lts.1\+'
   push:
     branches:
       - '23.lts.1\+'


### PR DESCRIPTION
The workflow was missing branch name for pull_request trigger.