### PR TITLE
Extract session id before writing it to GITHUB_ENV (21.lts.1+)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -183,7 +183,7 @@ jobs:
       - name: Trigger ${{ matrix.type }} tests on ${{ matrix.platform }} platform
         id: on_device_test
         run: |
-          echo "session_id=$(
+          SESSION_ID=$(
             python3 tools/on_device_tests_gateway_client.py \
               --token ${{ github.token }} \
               --change_id "${{ github.sha }}" \
@@ -209,14 +209,15 @@ jobs:
               --label repository-${{ github.repository }} \
               --label author-${{ github.event.pull_request.head.user.login || github.event.commits[0].author.username }} \
               --label author_id-${{ github.event.pull_request.head.user.id || github.event.commits[0].author.email }}
-          )" >> $GITHUB_ENV
+          )
+          echo "SESSION_ID=$SESSION_ID" >> $GITHUB_ENV
         shell: bash
       - name: Watch ${{ matrix.type }} tests on ${{ matrix.platform }} platform
         run: |
           python3 tools/on_device_tests_gateway_client.py \
             --token ${{ github.token }} \
             --change_id "${{ github.sha }}" \
-            watch ${{ env.session_id }}
+            watch ${{ env.SESSION_ID }}
 
   # Runs builds.
   build:


### PR DESCRIPTION
This fixes the problem where GitHub throws "Error: Unable to process file command 'env' successfully." error when MH invocation fails.

b/267508341