### PR TITLE
Adjust keepalive settings in ODT client.

### DIFF
--- a/tools/on_device_tests_gateway_client.py
+++ b/tools/on_device_tests_gateway_client.py
@@ -51,8 +51,8 @@ class OnDeviceTestsGatewayClient():
     self.channel = grpc.insecure_channel(
         target=f'{_ON_DEVICE_TESTS_GATEWAY_SERVICE_HOST}:{_ON_DEVICE_TESTS_GATEWAY_SERVICE_PORT}',  # pylint:disable=line-too-long
         # These options need to match server settings.
-        options=[('grpc.keepalive_time_ms', 10000),
-                 ('grpc.keepalive_timeout_ms', 5000),
+        options=[('grpc.keepalive_time_ms', 30000),
+                 ('grpc.keepalive_timeout_ms', 15000),
                  ('grpc.keepalive_permit_without_calls', 1),
                  ('grpc.http2.max_pings_without_data', 0),
                  ('grpc.http2.min_time_between_pings_ms', 10000),


### PR DESCRIPTION
Increase time between pings to 30 seconds.
Increase keepalive timeout to 15 seconds.

b/267656691