### PR TITLE
Ensure ordering of stashed deep links. (#212)

### DIFF
--- a/cobalt/base/deep_link_event.h
+++ b/cobalt/base/deep_link_event.h
@@ -16,20 +16,28 @@
 #define COBALT_BASE_DEEP_LINK_EVENT_H_
 
 #include <string>
+#include <utility>
 
 #include "base/callback.h"
 #include "base/compiler_specific.h"
 #include "base/strings/string_util.h"
 #include "cobalt/base/event.h"
+#include "cobalt/base/polymorphic_downcast.h"
 
 namespace base {
 
 class DeepLinkEvent : public Event {
  public:
   DeepLinkEvent(const std::string& link, const base::Closure& consumed_callback)
-      : link_(link), consumed_callback_(consumed_callback) {}
+      : link_(link), consumed_callback_(std::move(consumed_callback)) {}
+  explicit DeepLinkEvent(const Event* event) {
+    const base::DeepLinkEvent* deep_link_event =
+        base::polymorphic_downcast<const base::DeepLinkEvent*>(event);
+    link_ = deep_link_event->link();
+    consumed_callback_ = deep_link_event->callback();
+  }
   const std::string& link() const { return link_; }
-  const base::Closure& callback() const { return consumed_callback_; }
+  base::Closure callback() const { return consumed_callback_; }
 
   BASE_EVENT_SUBCLASS(DeepLinkEvent);
 

--- a/cobalt/h5vcc/h5vcc_runtime.cc
+++ b/cobalt/h5vcc/h5vcc_runtime.cc
@@ -14,14 +14,17 @@
 
 #include "cobalt/h5vcc/h5vcc_runtime.h"
 
-#include "base/synchronization/lock.h"
+#include <memory>
+#include <utility>
+
 #include "cobalt/base/deep_link_event.h"
 #include "cobalt/base/polymorphic_downcast.h"
 
 namespace cobalt {
 namespace h5vcc {
 H5vccRuntime::H5vccRuntime(base::EventDispatcher* event_dispatcher)
-    : event_dispatcher_(event_dispatcher) {
+    : event_dispatcher_(event_dispatcher),
+      message_loop_(base::MessageLoop::current()) {
   on_deep_link_ = new H5vccDeepLinkEventTarget(
       base::Bind(&H5vccRuntime::GetUnconsumedDeepLink, base::Unretained(this)));
   on_pause_ = new H5vccRuntimeEventTarget;
@@ -29,7 +32,7 @@ H5vccRuntime::H5vccRuntime(base::EventDispatcher* event_dispatcher)
 
   DCHECK(event_dispatcher_);
   deep_link_event_callback_ =
-      base::Bind(&H5vccRuntime::OnDeepLinkEvent, base::Unretained(this));
+      base::Bind(&H5vccRuntime::OnEventForDeepLink, base::Unretained(this));
   event_dispatcher_->AddEventCallback(base::DeepLinkEvent::TypeId(),
                                       deep_link_event_callback_);
 }
@@ -40,7 +43,7 @@ H5vccRuntime::~H5vccRuntime() {
 }
 
 std::string H5vccRuntime::initial_deep_link() {
-  base::AutoLock auto_lock(lock_);
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (consumed_callback_) {
     std::move(consumed_callback_).Run();
   }
@@ -51,7 +54,7 @@ std::string H5vccRuntime::initial_deep_link() {
 }
 
 const std::string& H5vccRuntime::GetUnconsumedDeepLink() {
-  base::AutoLock auto_lock(lock_);
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (!initial_deep_link_.empty() && consumed_callback_) {
     LOG(INFO) << "Returning stashed unconsumed deep link: "
               << initial_deep_link_;
@@ -81,11 +84,22 @@ void H5vccRuntime::TraceMembers(script::Tracer* tracer) {
   tracer->Trace(on_resume_);
 }
 
-void H5vccRuntime::OnDeepLinkEvent(const base::Event* event) {
-  base::AutoLock auto_lock(lock_);
-  const base::DeepLinkEvent* deep_link_event =
-      base::polymorphic_downcast<const base::DeepLinkEvent*>(event);
-  const std::string& link = deep_link_event->link();
+void H5vccRuntime::OnEventForDeepLink(const base::Event* event) {
+  std::unique_ptr<base::DeepLinkEvent> deep_link_event(
+      new base::DeepLinkEvent(event));
+  if (base::MessageLoop::current() != message_loop_) {
+    message_loop_->task_runner()->PostTask(
+        FROM_HERE,
+        base::Bind(&H5vccRuntime::OnDeepLinkEvent, base::Unretained(this),
+                   base::Passed(&deep_link_event)));
+    return;
+  }
+  OnDeepLinkEvent(std::move(deep_link_event));
+}
+
+void H5vccRuntime::OnDeepLinkEvent(std::unique_ptr<base::DeepLinkEvent> event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  const std::string& link = event->link();
   if (link.empty()) {
     return;
   }
@@ -94,13 +108,13 @@ void H5vccRuntime::OnDeepLinkEvent(const base::Event* event) {
     // Store the link for later consumption.
     LOG(INFO) << "Stashing deep link: " << link;
     initial_deep_link_ = link;
-    consumed_callback_ = deep_link_event->callback();
+    consumed_callback_ = event->callback();
   } else {
     // Send the link.
     DCHECK(consumed_callback_.is_null());
     LOG(INFO) << "Dispatching deep link event: " << link;
     on_deep_link()->DispatchEvent(link);
-    base::OnceClosure callback(deep_link_event->callback());
+    base::OnceClosure callback(event->callback());
     if (callback) {
       std::move(callback).Run();
     }


### PR DESCRIPTION
This ensures ordering of stashed deep links in H5vccRuntime by ensuring it's only done from the thread that instantiated the object.

b/263967861

Change-Id: I3e200cda6ba79afa205e5bcbe81c2dc13cb87c94

Co-authored-by: Jelle Foks <jfoks@google.com>