### PR TITLE
(19.lts.1+) Use gsutil to upload test archives. (#230)

### DIFF
--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -30,9 +30,7 @@ runs:
       shell: bash
     - name: Upload Archive
       id: upload-archive
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
-      with:
-        headers: |-
-          content-type: application/x-tar
-        path: ${{env.ARCHIVE_PATH}}
-        destination: ${{env.PROJECT_NAME}}-build-artifacts/${{env.WORKFLOW}}/${{env.TODAY}}/${{env.GITHUB_RUN_NUMBER}}/
+      shell: bash
+      run: |
+        set -uex
+        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -25,10 +25,7 @@ runs:
       shell: bash
     - name: Copy Test Files to GCS
       id: upload-test-archive
-      uses: google-github-actions/upload-cloud-storage@v0.10.4
-      with:
-        headers: |-
-          content-type: application/x-tar
-        path: ${{env.ARCHIVE_PATH}}
-        destination: ${{env.DESTINATION}}
-        parent: true
+      shell: bash
+      run: |
+        set -eux
+        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"


### PR DESCRIPTION
Gsutil appears to be twice as fast as google-github-actions/upload-cloud-storage. We also use gsutil to download artifacts and it never fails. Switching to gsutil with -d option should also help us with debug output printed to logs.

b/266771047