### PR TITLE
Use docker compose v2 to build win docker images

### DIFF
--- a/.github/actions/docker_win/action.yaml
+++ b/.github/actions/docker_win/action.yaml
@@ -54,15 +54,13 @@ runs:
       shell: bash
     - name: Build containers with docker-compose
       if: env.need_to_build == 'true'
-      uses: smartlyio/docker-compose-action@v1
       env:
         DOCKER_CPUS: 2
-      with:
-        serviceName: ${{inputs.service}}
-        build: false
-        push: "on:push"
-        composeArguments: "--no-start"
-        composeFile: "docker-compose-windows.yml"
+        SERVICE: ${{inputs.service}}
+      shell: bash
+      run: |
+        set -xue
+        docker compose -f docker-compose-windows.yml up --no-start "${SERVICE}"
     - name: Tag images
       if: ${{ (env.need_to_build == 'true') && ((github.event_name != 'pull_request') || (!github.event.pull_request.head.repo.fork)) }}
       run: |


### PR DESCRIPTION
Latest Windows 2019 GitHub runner image had docker engine upgraded from 20.10.23 to 23.0.1.  This caused incompatiblity with Docker Compose v1 which has been deprecated.  As of right now, there is no way to use Docker Compose v2 with smartlyio/docker-compose-action (see https://github.com/smartlyio/docker-compose-action/issues/567).

b/269780709