### PR TITLE
Add bug id check job to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,11 @@ name: lint
 
 on:
   pull_request:
-    branches: [main]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   push:
     branches: [main]
 
@@ -44,3 +48,14 @@ jobs:
         uses: ./.github/actions/pre_commit
         with:
           base_ref: ${{ github.event.pull_request.base.sha && github.event.pull_request.base.sha || github.event.before }}
+  check-bug-id:
+    name: Check Bug ID
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Bug ID Present
+        # v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
+        with:
+          pattern: '^b\/\d+$'
+          flags: 'gm'
+          error: 'Commit message should include at least one bug ID on a separate line (e.g. b/12345).'


### PR DESCRIPTION
Commit message workflow will contain all checks related to commit messages.  For now it checks for a bug ID only.
Expand linting and bug id check to legacy branches, and explicitly list types for triggers.

b/263984710