### PR TITLE
Pass correct platform parameter to ODT

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -216,7 +216,7 @@ jobs:
               --change_id "${{ github.sha }}" \
               trigger \
               --test_type ${{ matrix.type }} \
-              --platform ${{ matrix.target_platform }} \
+              --platform ${{ matrix.platform }} \
               --config ${{ matrix.config }} \
               --tag cobalt_github_${{ github.event_name }} \
               --builder_name github_${{ matrix.platform }}_tests \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -209,6 +209,7 @@ jobs:
       - name: trigger ${{ matrix.type }} tests on ${{ matrix.platform }} platform
         id: on_device_test
         run: |
+          set -eux
           SESSION_ID=$(
             python3 tools/on_device_tests_gateway_client.py \
               --token ${{ github.token }} \


### PR DESCRIPTION
MH infra for 22.lts.1+ and older branches expects variant name (e.g. 'sbersion-12') as part of --platform parameter value.

b/271325762