### PR TITLE
Remove evergreen test from arm-hardfp ODT.

### DIFF
--- a/.github/config/evergreen-arm-hardfp.json
+++ b/.github/config/evergreen-arm-hardfp.json
@@ -4,7 +4,6 @@
   "on_device_test": {
     "enabled": true,
     "tests": [
-      "evergreen_test",
       "unit_test"
     ]
   },


### PR DESCRIPTION
We don't run these tests on Buildbot.