### PR TITLE
Stop using smartlyio/docker-compose-action (#396)

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -55,6 +55,7 @@ runs:
         GITHUB_EVENT_NUMBER: ${{ github.event.number }}
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
+        set -x
         # Need to login to GCR to be able to push images created by fork based PR workflows.
         PROJECT_NAME=$(gcloud config get-value project)
         METADATA="http://metadata.google.internal./computeMetadata/v1"
@@ -66,7 +67,6 @@ runs:
     - name: Process Docker metadata
       id: process-docker-metadata
       run: |
-        set -x
         set +e
         docker manifest inspect $DOCKER_TAG > /dev/null
         if [[ $? -ne 0 || ${{ steps.changed-files.outputs.any_changed }} == 'true' ]]; then
@@ -78,13 +78,12 @@ runs:
     - name: Build containers with docker-compose
       id: build-image
       if: env.need_to_build == 'true'
-      uses: smartlyio/docker-compose-action@83392e28664cc0cb5b3208e8d75697d01da8db18 # v1.7.1
-      with:
-        serviceName: ${{ inputs.docker_service }}
-        build: false
-        push: "on:push"
-        composeArguments: "--no-start"
-        composeFile: "docker-compose.yml"
+      env:
+        SERVICE: ${{inputs.docker_service}}
+      shell: bash
+      run: |
+        set -xue
+        DOCKER_BUILDKIT=0 docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
     - name: Tag images
       id: tag-images
       if: env.need_to_build == 'true'


### PR DESCRIPTION
As of right now, there is no way to use
Docker Compose v2 with smartlyio/docker-compose-action. Docker Compose v1 has been deprecated and use of v1 is causing compatability issues with ARC infra.

b/280495066
b/278624932