### PR TITLE
Stop using smartlyio/docker-compose-action (#396)

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -78,13 +78,12 @@ runs:
     - name: Build containers with docker-compose
       id: build-image
       if: env.need_to_build == 'true'
-      uses: smartlyio/docker-compose-action@83392e28664cc0cb5b3208e8d75697d01da8db18 # v1.7.1
-      with:
-        serviceName: ${{ inputs.docker_service }}
-        build: false
-        push: "on:push"
-        composeArguments: "--no-start"
-        composeFile: "docker-compose.yml"
+      env:
+        SERVICE: ${{inputs.docker_service}}
+      shell: bash
+      run: |
+        set -xue
+        DOCKER_BUILDKIT=0 docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
     - name: Tag images
       id: tag-images
       if: env.need_to_build == 'true'

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_OS
 ARG BASE_OS_TAG
-FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian9}:${BASE_OS_TAG:-latest}
+FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian10}:${BASE_OS_TAG:-latest}
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
As of right now, there is no way to use
Docker Compose v2 with smartlyio/docker-compose-action. Docker Compose v1 has been deprecated and use of v1 is causing compatability issues with ARC infra.

b/280495066
b/278624932