### PR TITLE
Keep built Android APKs as artifacts

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -1,6 +1,8 @@
 name: android
 
 on:
+  release:
+    types: [prereleased, released, published]
   pull_request:
     types: [opened, reopened, synchronize, labeled]
     branches:
@@ -30,6 +32,7 @@ jobs:
     with:
       platform: android-arm64
       nightly: ${{ github.event.inputs.nightly }}
+      keep_artifacts: cobalt.apk
   android-x86:
     uses: ./.github/workflows/main.yaml
     permissions:
@@ -38,6 +41,7 @@ jobs:
     with:
       platform: android-x86
       nightly: ${{ github.event.inputs.nightly }}
+      keep_artifacts: cobalt.apk
   android-arm:
     uses: ./.github/workflows/main.yaml
     permissions:
@@ -46,3 +50,55 @@ jobs:
     with:
       platform: android-arm
       nightly: ${{ github.event.inputs.nightly }}
+      keep_artifacts: cobalt.apk
+
+  final_android_job:
+    runs-on: ubuntu-latest
+    needs: [ android-arm, android-arm64, android-x86 ]
+    permissions:
+      actions: write
+    steps:
+      - name: Download arm-gold apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-arm-gold
+          path: arm-gold
+      - name: Download arm-qa apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-arm-qa
+          path: arm-qa
+      - name: Download arm64-gold apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-arm64-gold
+          path: arm64-gold
+      - name: Download arm64-qa apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-arm64-gold
+          path: arm64-qa
+      - name: Download x86-gold apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-x86-gold
+          path: x86-gold
+      - name: Download x86-qa apk
+        uses: actions/download-artifact@v4
+        with:
+          name: android-x86-gold
+          path: x86-qa
+      - name: 'Upload Android APKs'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Android APKs
+          path: ./*
+          retention-days: 90
+          compression-level: 0 # We expect kept artifacts to be already compressed
+          if-no-files-found: error
+      - name: 'Delete intermediates'
+        uses: geekyeggo/delete-artifact@9d15d164b1dcd538ff1b1a2984bc2c0240986c3b # v4.0.0
+        with:
+          token: ${{ github.token }}
+          name: android-arm-qa
+          failOnError: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,11 @@ on:
         required: false
         type: boolean
         default: false
+      keep_artifacts:
+        description: 'Which artifacts to keep for releases'
+        required: false
+        type: string
+        default: ''
 
 # Global env vars.
 env:
@@ -238,6 +243,15 @@ jobs:
         uses: ./.github/actions/gn
       - name: Build Cobalt
         uses: ./.github/actions/build
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v4
+        if: inputs.keep_artifacts
+        with:
+          name: ${{ matrix.platform }}-${{ matrix.config }}
+          path: out/${{ matrix.platform }}_${{ matrix.config }}/${{ inputs.keep_artifacts }}
+          retention-days: 7
+          compression-level: 0 # We expect kept artifacts to be already compressed
+          if-no-files-found: error
       - name: Run API Leak Detector
         uses: ./.github/actions/api_leak_detector
         if: inputs.run_api_leak_detector


### PR DESCRIPTION
Preserves build APKs in a single bundle for all architectures. This is intended to keep APKs with every release.

b/290121545
b/318577880