### PR TITLE
Add smoke tests

### DIFF
--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -80,7 +80,7 @@ runs:
           --label branch:${GITHUB_REF_NAME} \
           --dimensions '${{ inputs.test_dimensions }}' \
           --artifact_name '${{ inputs.artifact_name }}' \
-          --workflow '${GITHUB_WORKFLOW}' \
+          --workflow "${GITHUB_WORKFLOW}" \
           --cobalt_path "${GCS_ARTIFACTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."

--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -36,7 +36,7 @@ runs:
       shell: bash
     - name: Run Tests on ${{ matrix.platform }} Platform
       env:
-        GCS_ARTIFACTS_PATH: /bigstore/${{ env.PROJECT_NAME }}-test-artifacts/${{ github.workflow }}/${{ github.run_number }}/${{ matrix.platform }}/${{ matrix.platform }}_qa/${{ inputs.artifact_name }}
+        GCS_ARTIFACTS_PATH: ${{ env.PROJECT_NAME }}-test-artifacts/${{ github.workflow }}/${{ github.run_number }}/${{ matrix.platform }}/${{ matrix.platform }}_qa
         GITHUB_SHA: ${{ github.sha }}
         GITHUB_TOKEN: ${{ github.token }}
         GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -79,6 +79,8 @@ runs:
           --label author_id-${GITHUB_PR_HEAD_USER_ID:-$GITHUB_COMMIT_AUTHOR_EMAIL} \
           --label branch:${GITHUB_REF_NAME} \
           --dimensions '${{ inputs.test_dimensions }}' \
+          --artifact_name '${{ inputs.artifact_name }}' \
+          --workflow '${GITHUB_WORKFLOW}' \
           --cobalt_path "${GCS_ARTIFACTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."

--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -13,7 +13,7 @@ inputs:
   artifact_name:
     description: "The name of the artifact to be used for tests (e.g., Cobalt.apk)."
     default: "Cobalt.apk"
-  device_family:
+  test_device_family:
     description: "The test device family (e.g., raspi, rdk)."
     default: ""
 
@@ -83,7 +83,7 @@ runs:
           --label branch:${GITHUB_REF_NAME} \
           --dimensions '${{ inputs.test_dimensions }}' \
           --artifact_name '${{ inputs.artifact_name }}' \
-          --device_family '${{ inputs.device_family }}' \
+          --device_family '${{ inputs.test_device_family }}' \
           --cobalt_path "${GCS_ARTIFACTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."

--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -13,6 +13,9 @@ inputs:
   artifact_name:
     description: "The name of the artifact to be used for tests (e.g., Cobalt.apk)."
     default: "Cobalt.apk"
+  device_family:
+    description: "The test device family (e.g., raspi, rdk)."
+    default: ""
 
 runs:
   using: "composite"
@@ -80,7 +83,7 @@ runs:
           --label branch:${GITHUB_REF_NAME} \
           --dimensions '${{ inputs.test_dimensions }}' \
           --artifact_name '${{ inputs.artifact_name }}' \
-          --workflow "${GITHUB_WORKFLOW}" \
+          --device_family '${{ inputs.device_family }}' \
           --cobalt_path "${GCS_ARTIFACTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."

--- a/.github/config/evergreen-arm-hardfp-raspi.json
+++ b/.github/config/evergreen-arm-hardfp-raspi.json
@@ -26,7 +26,11 @@
   "e2e_test_targets": [
     {
       "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_raspi",
-      "test_attempts": "3"
+      "test_attempts": "6"
+    },
+    {
+      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_custom_cobalt_raspi",
+      "test_attempts": "6"
     }
   ]
 }

--- a/.github/config/evergreen-arm-hardfp-raspi.json
+++ b/.github/config/evergreen-arm-hardfp-raspi.json
@@ -6,6 +6,7 @@
   "test_package": true,
   "test_on_device": true,
   "test_device_family": "raspi",
+  "test_e2e": true,
   "test_root_target": "//cobalt:gn_all",
   "test_attempts": "3",
   "test_dimensions": {
@@ -20,6 +21,12 @@
     {
       "name": "arm-hardfp-raspi",
       "platform": "evergreen-arm-hardfp-raspi"
+    }
+  ],
+  "e2e_test_targets": [
+    {
+      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_raspi",
+      "test_attempts": "3"
     }
   ]
 }

--- a/.github/config/evergreen-arm-hardfp-raspi.json
+++ b/.github/config/evergreen-arm-hardfp-raspi.json
@@ -25,10 +25,6 @@
   ],
   "e2e_test_targets": [
     {
-      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_raspi",
-      "test_attempts": "6"
-    },
-    {
       "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_custom_cobalt_raspi",
       "test_attempts": "6"
     }

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -26,7 +26,11 @@
   "e2e_test_targets": [
     {
       "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_rdk",
-      "test_attempts": "3"
+      "test_attempts": "6"
+    },
+    {
+      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_custom_cobalt_rdk",
+      "test_attempts": "6"
     }
   ]
 }

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -25,10 +25,6 @@
   ],
   "e2e_test_targets": [
     {
-      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_rdk",
-      "test_attempts": "6"
-    },
-    {
       "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_custom_cobalt_rdk",
       "test_attempts": "6"
     }

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -6,6 +6,7 @@
   "test_package": true,
   "test_on_device": true,
   "test_device_family": "rdk",
+  "test_e2e": true,
   "test_root_target": "//cobalt:gn_all",
   "test_attempts": "3",
   "test_dimensions": {
@@ -20,6 +21,12 @@
     {
       "name": "arm-hardfp-rdk",
       "platform": "evergreen-arm-hardfp-rdk"
+    }
+  ],
+  "e2e_test_targets": [
+    {
+      "target": "//video/youtube/web/living_room/kabuki/testing/end2end/browse:infra_smoke_test_cobalt_26_eap_rdk",
+      "test_attempts": "3"
     }
   ]
 }

--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -75,6 +75,15 @@ jobs:
       upstream_branches: ${{ steps.set-upstream-branches.outputs.upstream_branches }}
       downstream_branch: ${{ steps.set-downstream-branch.outputs.downstream_branch }}
       code_ownership: ${{ steps.set-code-ownership.outputs.code_ownership }}
+  calculate_diffs_without_upstream:
+    needs: initialize
+    runs-on: ubuntu-latest
+    if: ${{ needs.initialize.outputs.upstream_branches == '' }}
+    steps:
+      - name: BLAH
+        run: |
+          set -eux
+          echo "hello there's no upstream"
   calculate_diffs:
     needs: initialize
     # Check if there's any diff to perform

--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -75,15 +75,6 @@ jobs:
       upstream_branches: ${{ steps.set-upstream-branches.outputs.upstream_branches }}
       downstream_branch: ${{ steps.set-downstream-branch.outputs.downstream_branch }}
       code_ownership: ${{ steps.set-code-ownership.outputs.code_ownership }}
-  calculate_diffs_without_upstream:
-    needs: initialize
-    runs-on: ubuntu-latest
-    if: ${{ needs.initialize.outputs.upstream_branches == '' }}
-    steps:
-      - name: BLAH
-        run: |
-          set -eux
-          echo "hello there's no upstream"
   calculate_diffs:
     needs: initialize
     # Check if there's any diff to perform

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -460,6 +460,7 @@ jobs:
           test_type: 'e2e_test'
           test_targets: '${{ needs.initialize.outputs.e2e_test_targets }}'
           test_dimensions: '${{ needs.initialize.outputs.test_dimensions }}'
+          test_device_family: '${{ needs.initialize.outputs.test_device_family}}'
 
   yts-test:
     needs: [initialize, build]

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -372,12 +372,6 @@ def main() -> int:
       default='900',
       help='Timeout in seconds for the test to start.',
   )
-  trigger_args.add_argument(
-      '-a',
-      '--gcs_archive_path',
-      type=str,
-      help='Path to Cobalt archive to be tested. Must be on GCS.',
-  )
 
   # --- Unit Test Arguments ---
   unit_test_group = trigger_parser.add_argument_group('Unit Test Arguments')
@@ -385,6 +379,12 @@ def main() -> int:
       '--filter_json_dir',
       type=str,
       help='Directory containing filter JSON files for test selection.',
+  )
+  unit_test_group.add_argument(
+      '-a',
+      '--gcs_archive_path',
+      type=str,
+      help='Path to Cobalt archive to be tested. Must be on GCS.',
   )
   unit_test_group.add_argument(
       '--gcs_result_path',
@@ -425,6 +425,9 @@ def main() -> int:
   args = parser.parse_args()
 
   # TODO(b/428961033): Let argparse handle these checks as required arguments.
+  if args.test_type in ('e2e_test', 'yts_test'):
+    if not args.cobalt_path:
+      raise ValueError('--cobalt_path is required for e2e_test or yts_test')
   elif args.test_type == 'unit_test':
     if not args.device_family:
       raise ValueError('--device_family is required for unit_test')

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -253,6 +253,8 @@ def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
       test_cmd_args = []
       files = [f'cobalt_path={args.cobalt_path}']
       params = [f'yt_binary_name={_E2E_DEFAULT_YT_BINARY_NAME}']
+      if args.gcs_archive_path:
+        params.append(f'gcs_cobalt_archive={args.gcs_archive_path}')
 
     else:
       raise ValueError(f'Unsupported test type: {args.test_type}')
@@ -367,6 +369,12 @@ def main() -> int:
       default='900',
       help='Timeout in seconds for the test to start.',
   )
+  trigger_args.add_argument(
+      '-a',
+      '--gcs_archive_path',
+      type=str,
+      help='Path to Cobalt archive to be tested. Must be on GCS.',
+  )
 
   # --- Unit Test Arguments ---
   unit_test_group = trigger_parser.add_argument_group('Unit Test Arguments')
@@ -374,12 +382,6 @@ def main() -> int:
       '--filter_json_dir',
       type=str,
       help='Directory containing filter JSON files for test selection.',
-  )
-  unit_test_group.add_argument(
-      '-a',
-      '--gcs_archive_path',
-      type=str,
-      help='Path to Cobalt archive to be tested. Must be on GCS.',
   )
   unit_test_group.add_argument(
       '--gcs_result_path',

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -254,7 +254,7 @@ def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
       params = [f'yt_binary_name={_E2E_DEFAULT_YT_BINARY_NAME}']
       files = []
       if args.workflow == 'evergreen':
-        params.append(f'gcs_cobalt_archive=gs://{args.gcs_archive_path}.zip')
+        params.append(f'gcs_cobalt_archive=gs://{args.cobalt_path}.zip')
       else:
         bigstore_path = f'/bigstore/{args.cobalt_path}/{args.artifact_name}'
         files.append(f'cobalt_path={bigstore_path}')

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -320,7 +320,6 @@ def main() -> int:
   trigger_args.add_argument(
       '--device_family',
       type=str,
-      choices=['android', 'raspi', 'rdk'],
       help='Family of device to run tests on.',
   )
   trigger_args.add_argument(

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -251,7 +251,9 @@ def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
       elif args.test_attempts:
         test_args.extend([f'test_attempts={args.test_attempts}'])
       test_cmd_args = []
-      files = [f'cobalt_path={args.cobalt_path}']
+      files = []
+      if args.cobalt_path:
+        files.append(f'cobalt_path={args.cobalt_path}')
       params = [f'yt_binary_name={_E2E_DEFAULT_YT_BINARY_NAME}']
       if args.gcs_archive_path:
         params.append(f'gcs_cobalt_archive={args.gcs_archive_path}')
@@ -411,9 +413,6 @@ def main() -> int:
   args = parser.parse_args()
 
   # TODO(b/428961033): Let argparse handle these checks as required arguments.
-  if args.test_type in ('e2e_test', 'yts_test'):
-    if not args.cobalt_path:
-      raise ValueError('--cobalt_path is required for e2e_test or yts_test')
   elif args.test_type == 'unit_test':
     if not args.device_family:
       raise ValueError('--device_family is required for unit_test')

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -251,12 +251,13 @@ def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
       elif args.test_attempts:
         test_args.extend([f'test_attempts={args.test_attempts}'])
       test_cmd_args = []
-      files = []
-      if args.cobalt_path:
-        files.append(f'cobalt_path={args.cobalt_path}')
       params = [f'yt_binary_name={_E2E_DEFAULT_YT_BINARY_NAME}']
-      if args.gcs_archive_path:
-        params.append(f'gcs_cobalt_archive={args.gcs_archive_path}')
+      files = []
+      if args.workflow == 'evergreen':
+        params.append(f'gcs_cobalt_archive=gs://{args.gcs_archive_path}.zip')
+      else:
+        bigstore_path = f'/bigstore/{args.cobalt_path}/{args.artifact_name}'
+        files.append(f'cobalt_path={bigstore_path}')
 
     else:
       raise ValueError(f'Unsupported test type: {args.test_type}')
@@ -397,6 +398,17 @@ def main() -> int:
       '--cobalt_path',
       type=str,
       help='Path to Cobalt apk.',
+  )
+  e2e_test_group.add_argument(
+      '--workflow',
+      type=str,
+      help='Workflow name.',
+  )
+  e2e_test_group.add_argument(
+      '--artifact_name',
+      type=str,
+      help=('Artifact name, used to specify the cobalt path in non-evergreen'
+            ' workflows'),
   )
 
   # Watch command

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -253,7 +253,7 @@ def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
       test_cmd_args = []
       params = [f'yt_binary_name={_E2E_DEFAULT_YT_BINARY_NAME}']
       files = []
-      if args.workflow == 'evergreen':
+      if args.device_family in ['rdk', 'raspi']:
         params.append(f'gcs_cobalt_archive=gs://{args.cobalt_path}.zip')
       else:
         bigstore_path = f'/bigstore/{args.cobalt_path}/{args.artifact_name}'
@@ -398,11 +398,6 @@ def main() -> int:
       '--cobalt_path',
       type=str,
       help='Path to Cobalt apk.',
-  )
-  e2e_test_group.add_argument(
-      '--workflow',
-      type=str,
-      help='Workflow name.',
   )
   e2e_test_group.add_argument(
       '--artifact_name',


### PR DESCRIPTION
CI: Add Smoke Tests for Raspberry Pi and RDK

This change enables the execution of smoke tests for Raspberry Pi (raspi) and RDK platforms. It integrates these tests into the existing `internal_tests` GitHub Action workflow. Configuration for these platforms has been updated in the respective JSON files. The `on_device_tests_gateway_client.py` script has been modified to support these tests.

Bug: 470180018